### PR TITLE
ci: add lint, typecheck, and build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint-typecheck-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Run TypeScript check
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow running on pushes to `main` and on pull requests:

1. `npm run lint` — ESLint
2. `npm run typecheck` — `tsc --noEmit`
3. `npm run build` — production Next.js build

The first two are what `npm test` already runs locally. The build step is added because it catches errors the other two miss.

Mirrors `still`'s workflow, with npm dependency caching added. Node pinned to 24.

## Verification

All three steps run green locally against a clean `npm ci`.

## Noticed while here (not addressed in this PR)

- `tsconfig.tsbuildinfo` is tracked in git but is a build artifact — running a build dirties the working tree. It should probably be in `.gitignore` and removed from the index.
- `npm run lint` uses `next lint`, which is deprecated and prints a migration notice pointing at `@next/codemod next-lint-to-eslint-cli`. Worth migrating to the ESLint CLI directly at some point.